### PR TITLE
Recalculate cutoff for Judged measure.

### DIFF
--- a/ir_measures/measures/judged.py
+++ b/ir_measures/measures/judged.py
@@ -12,7 +12,7 @@ class _Judged(measures.Measure):
     PRETTY_NAME = 'Judgment Rate at k'
     SHORT_DESC = 'The percentage of results in the top k that have a relevance judgment.'
     SUPPORTED_PARAMS = {
-        'cutoff': measures.ParamInfo(dtype=int, required=True, desc='ranking cutoff threshold'),
+        'cutoff': measures.ParamInfo(dtype=int, required=False, desc='ranking cutoff threshold'),
     }
 
 

--- a/ir_measures/providers/judged_provider.py
+++ b/ir_measures/providers/judged_provider.py
@@ -39,7 +39,13 @@ class JudgedEvaluator(providers.Evaluator):
             qid_qrels = self.qrels.get(qid)
             if qid_qrels:
                 for cutoff, measure in self.cutoffs:
-                    cutoff_run = sorted_run.get(qid, [])[:cutoff]
+                    current_run = sorted_run.get(qid, [])
+                    # When there is no cutoff, default to the
+                    # size of the run.
+                    if cutoff == NOT_PROVIDED:
+                        cutoff = len(current_run)
+
+                    cutoff_run = current_run[:cutoff]
                     judged_c = sum((did in qid_qrels) for did, _ in cutoff_run)
 
                     # The cutoff should be recalculated if it is
@@ -50,7 +56,7 @@ class JudgedEvaluator(providers.Evaluator):
                     # A cutoff larger than the run size causes
                     # this calculation to be incorrect.
                     value = judged_c / cutoff
-                    
+
                     yield Metric(query_id=qid, measure=measure, value=value)
 
 

--- a/ir_measures/providers/judged_provider.py
+++ b/ir_measures/providers/judged_provider.py
@@ -39,8 +39,18 @@ class JudgedEvaluator(providers.Evaluator):
             qid_qrels = self.qrels.get(qid)
             if qid_qrels:
                 for cutoff, measure in self.cutoffs:
-                    judged_c = sum((did in qid_qrels) for did, _ in sorted_run.get(qid, [])[:cutoff])
+                    cutoff_run = sorted_run.get(qid, [])[:cutoff]
+                    judged_c = sum((did in qid_qrels) for did, _ in cutoff_run)
+
+                    # The cutoff should be recalculated if it is
+                    # less than the size of then run.
+                    if len(cutoff_run) < cutoff:
+                        cutoff = len(cutoff_run)
+
+                    # A cutoff larger than the run size causes
+                    # this calculation to be incorrect.
                     value = judged_c / cutoff
+                    
                     yield Metric(query_id=qid, measure=measure, value=value)
 
 

--- a/test/test_judged.py
+++ b/test/test_judged.py
@@ -30,6 +30,7 @@ class TestMeasures(unittest.TestCase):
         provider = ir_measures.judged
 
         expected_results = [
+            [Judged, [('0', 1.0), ('1', 1.0 / 4.0)]],
             [Judged(cutoff=1000), [('0', 1.0), ('1', 1.0 / 4.0)]],
             [Judged(cutoff=10), [('0', 1.0), ('1', 1.0 / 4.0)]],
             [Judged(cutoff=3), [('0', 1.0), ('1', 1.0 / 3.0)]],

--- a/test/test_judged.py
+++ b/test/test_judged.py
@@ -1,0 +1,48 @@
+import unittest
+import ir_measures
+from ir_measures.measures import Judged
+
+
+class TestMeasures(unittest.TestCase):
+
+    def test_judged(self):
+        qrels = list(ir_measures.read_trec_qrels('''
+0 0 D0 0
+0 0 D1 1
+0 0 D2 1
+0 0 D3 2
+0 0 D4 0
+1 0 D0 1
+1 0 D3 2
+1 0 D5 2
+'''))
+        run = list(ir_measures.read_trec_run('''
+0 0 D0 1 0.8 run
+0 0 D2 2 0.7 run
+0 0 D1 3 0.3 run
+0 0 D3 4 0.4 run
+0 0 D4 5 0.1 run
+1 0 D1 1 0.8 run
+1 0 D3 2 0.7 run
+1 0 D4 3 0.3 run
+1 0 D2 4 0.4 run
+'''))
+        provider = ir_measures.judged
+        # based on a manual execution of cwl-eval
+        expected_results = [
+            [Judged(cutoff=1000), [('0', 1.0), ('1', 1.0 / 4.0)]],
+            [Judged(cutoff=10), [('0', 1.0), ('1', 1.0 / 4.0)]],
+            [Judged(cutoff=3), [('0', 1.0), ('1', 1.0 / 3.0)]],
+            [Judged(cutoff=1), [('0', 1.0), ('1', 0.0)]],
+        ]
+        for measure, expected in expected_results:
+            with self.subTest(measure=measure):
+                self.assertTrue(provider.supports(measure))
+                results = list(provider.iter_calc([measure], qrels, run))
+                for result, (query_id, value) in zip(results, expected):
+                    self.assertAlmostEqual(result.query_id, query_id, delta=0.0001)
+                    self.assertAlmostEqual(result.value, value, delta=0.0001)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_judged.py
+++ b/test/test_judged.py
@@ -28,7 +28,7 @@ class TestMeasures(unittest.TestCase):
 1 0 D2 4 0.4 run
 '''))
         provider = ir_measures.judged
-        # based on a manual execution of cwl-eval
+
         expected_results = [
             [Judged(cutoff=1000), [('0', 1.0), ('1', 1.0 / 4.0)]],
             [Judged(cutoff=10), [('0', 1.0), ('1', 1.0 / 4.0)]],


### PR DESCRIPTION
The judged measure will report an incorrect value if the size of the run is less than the cutoff. I don't think this should be expected behavior and this PR recalculates the cutoff if it is less than the size of the run for the Judged measure.